### PR TITLE
Fix nil pointer dereference in GetPersistentShell

### DIFF
--- a/internal/llm/tools/shell/shell.go
+++ b/internal/llm/tools/shell/shell.go
@@ -47,8 +47,10 @@ func GetPersistentShell(workingDir string) *PersistentShell {
 		shellInstance = newPersistentShell(workingDir)
 	})
 
-	if shellInstance == nil || !shellInstance.isAlive {
+	if shellInstance == nil {
 		shellInstance = newPersistentShell(workingDir)
+	} else if !shellInstance.isAlive {
+		shellInstance = newPersistentShell(shellInstance.cwd)
 	}
 
 	return shellInstance

--- a/internal/llm/tools/shell/shell.go
+++ b/internal/llm/tools/shell/shell.go
@@ -48,7 +48,7 @@ func GetPersistentShell(workingDir string) *PersistentShell {
 	})
 
 	if shellInstance == nil || !shellInstance.isAlive {
-		shellInstance = newPersistentShell(shellInstance.cwd)
+		shellInstance = newPersistentShell(workingDir)
 	}
 
 	return shellInstance

--- a/internal/llm/tools/shell/shell.go
+++ b/internal/llm/tools/shell/shell.go
@@ -47,7 +47,7 @@ func GetPersistentShell(workingDir string) *PersistentShell {
 		shellInstance = newPersistentShell(workingDir)
 	})
 
-	if !shellInstance.isAlive {
+	if shellInstance == nil || !shellInstance.isAlive {
 		shellInstance = newPersistentShell(shellInstance.cwd)
 	}
 


### PR DESCRIPTION
## Issue
The application was crashing with a "runtime error: invalid memory address or nil pointer dereference" in the shell tool. This occurred because the GetPersistentShell function was attempting to access properties of a potentially nil shellInstance. Here is the exact panic log:

```
Panic in agent.Run: runtime error: invalid memory address or nil pointer dereference

Time: 2025-04-26T22:48:32+03:00

Stack Trace:
goroutine 139 [running]:
runtime/debug.Stack()
        /home/avi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
github.com/opencode-ai/opencode/internal/logging.RecoverPanic({0x1b5d7c8, 0x9}, 0xc00005df90)
        /home/avi/go/pkg/mod/github.com/opencode-ai/opencode@v0.0.27/internal/logging/logger.go:68 +0x325
panic({0x18426c0?, 0x2fa2350?})
        /home/avi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/runtime/panic.go:792 +0x132
github.com/opencode-ai/opencode/internal/llm/tools/shell.GetPersistentShell({0x7ffe16419c39?, 0xc003d8a7b0?})
        /home/avi/go/pkg/mod/github.com/opencode-ai/opencode@v0.0.27/internal/llm/tools/shell/shell.go:50 +0x4f
github.com/opencode-ai/opencode/internal/llm/tools.(*bashTool).Run(0xc00185a000, {0x217ff68, 0xc003d8a7b0}, {{0xc0007ba0e4, 0x1e}, {0xc0007ba126, 0x4}, {0xc0027ee468, 0x11}})
        /home/avi/go/pkg/mod/github.com/opencode-ai/opencode@v0.0.27/internal/llm/tools/bash.go:287 +0x812
github.com/opencode-ai/opencode/internal/llm/agent.(*agent).streamAndHandleEvents(0xc0001cd8c0, {0x217ffa0, 0xc00059e9b0}, {0xc0006885a0, 0x24}, {0xc003d1cb40?, 0x23c?, 0x1730160?})
        /home/avi/go/pkg/mod/github.com/opencode-ai/opencode@v0.0.27/internal/llm/agent/agent.go:313 +0xcad
github.com/opencode-ai/opencode/internal/llm/agent.(*agent).processGeneration(0xc0001cd8c0, {0x217ffa0, 0xc00059e9b0}, {0xc0006885a0, 0x24}, {0x1bd16c8, 0x23c})
        /home/avi/go/pkg/mod/github.com/opencode-ai/opencode@v0.0.27/internal/llm/agent/agent.go:221 +0x645
github.com/opencode-ai/opencode/internal/llm/agent.(*agent).Run.func1()
        /home/avi/go/pkg/mod/github.com/opencode-ai/opencode@v0.0.27/internal/llm/agent/agent.go:175 +0x1a5
created by github.com/opencode-ai/opencode/internal/llm/agent.(*agent).Run in goroutine 1
        /home/avi/go/pkg/mod/github.com/opencode-ai/opencode@v0.0.27/internal/llm/agent/agent.go:169 +0x196
```

## Root Cause
The newPersistentShell function can return nil in error cases (when failing to create stdin pipe or when cmd.Start() fails), but GetPersistentShell wasn't checking for this possibility before accessing shellInstance.isAlive.

## Solution
Added a nil check in GetPersistentShell before accessing shellInstance.isAlive to safely handle cases where shell initialization fails. This prevents the panic and ensures the code attempts to create a new shell instance when needed.