### PR TITLE
fix: gemini tool calling

### DIFF
--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -132,7 +132,8 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 }
 
 func (g *geminiClient) convertTools(tools []tools.BaseTool) []*genai.Tool {
-	geminiTools := make([]*genai.Tool, 0, len(tools))
+	geminiTool := &genai.Tool{}
+	geminiTool.FunctionDeclarations = make([]*genai.FunctionDeclaration, 0, len(tools))
 
 	for _, tool := range tools {
 		info := tool.Info()
@@ -146,12 +147,10 @@ func (g *geminiClient) convertTools(tools []tools.BaseTool) []*genai.Tool {
 			},
 		}
 
-		geminiTools = append(geminiTools, &genai.Tool{
-			FunctionDeclarations: []*genai.FunctionDeclaration{declaration},
-		})
+		geminiTool.FunctionDeclarations = append(geminiTool.FunctionDeclarations, declaration)
 	}
 
-	return geminiTools
+	return []*genai.Tool{geminiTool}
 }
 
 func (g *geminiClient) finishReason(reason genai.FinishReason) message.FinishReason {


### PR DESCRIPTION
Fix gemini tool calling:
- the docs show an example with multiple functions as 1 tool having multiple function declarations, see https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#javascript_9 and `houseFns`
- Asking Gemini what tools it has available, it said only "bash" as it was the first tool in the tool list
   - tried to use `cat` even though it's not allowed 
- asking it now lists tries listing all the tools, but crashes opencode - https://github.com/opencode-ai/opencode/issues/35, seems like it's some formatting issue when it starts listing the tools


Happy to make any changes if needed!


