### PR TITLE
Update styles.go to 

### DIFF
--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -13,8 +13,8 @@ var (
 // NEW STYLES
 var (
 	Background = lipgloss.AdaptiveColor{
-		Dark:  "#212121",
-		Light: "#212121",
+		Dark:  dark.Base().Hex,
+		Light: light.Base().Hex,
 	}
 	BackgroundDim = lipgloss.AdaptiveColor{
 		Dark:  "#2c2c2c",
@@ -30,8 +30,8 @@ var (
 	}
 
 	Forground = lipgloss.AdaptiveColor{
-		Dark:  "#d3d3d3",
-		Light: "#d3d3d3",
+		Dark:  dark.Text().Hex,
+		Light: light.Text().Hex,
 	}
 
 	ForgroundMid = lipgloss.AdaptiveColor{


### PR DESCRIPTION
Try to fix problem with terminal styles printing text in the same color as the background. This is what chatgpt suggested might be the solution to fix this.

This pull requests fixes some of the messages but not all. See example screen shot below:

<img width="807" alt="Screenshot 2025-04-29 at 7 09 20 PM" src="https://github.com/user-attachments/assets/92453889-59e5-49b3-b7f2-6be97fae114e" />

I believe there are other changes that need to be made in the messages.go file related to the ForgroundDim style. Please advise if you have any suggestions.