### PR TITLE
Refine mcp server configuration type

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can configure OpenCode using environment variables:
 
 ```json
 {
+  "$schema": "https://raw.githubusercontent.com/opencode-ai/opencode/main/opencode-schema.json",
   "data": {
     "directory": ".opencode"
   },

--- a/opencode-schema.json
+++ b/opencode-schema.json
@@ -260,44 +260,71 @@
       "additionalProperties": {
         "description": "MCP server configuration",
         "properties": {
-          "args": {
-            "description": "Command arguments for the MCP server",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "command": {
-            "description": "Command to execute for the MCP server",
-            "type": "string"
-          },
-          "env": {
-            "description": "Environment variables for the MCP server",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "headers": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "HTTP headers for SSE type MCP servers",
-            "type": "object"
-          },
           "type": {
             "default": "stdio",
             "description": "Type of MCP server",
             "enum": ["stdio", "sse"],
             "type": "string"
-          },
-          "url": {
-            "description": "URL for SSE type MCP servers",
-            "type": "string"
           }
         },
-        "required": ["command"],
-        "type": "object"
+        "oneOf": [
+          {
+            "title": "Stdio MCP Server",
+            "description": "Configuration for an MCP server communicating via standard I/O",
+            "properties": {
+              "type": {
+                "description": "Type of MCP server",
+                "const": "stdio"
+              },
+              "command": {
+                "description": "Command to execute for the MCP server",
+                "type": "string"
+              },
+              "args": {
+                "description": "Command arguments for the MCP server",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "env": {
+                "description": "Environment variables for the MCP server",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": ["command"],
+            "type": "object",
+            "additionalProperties": false
+          },
+          {
+            "title": "SSE MCP Server",
+            "description": "Configuration for an MCP server communicating via Server-Sent Events (SSE)",
+            "properties": {
+              "type": {
+                "description": "Type of MCP server",
+                "const": "sse"
+              },
+              "url": {
+                "description": "URL for the SSE endpoint",
+                "type": "string",
+                "format": "uri"
+              },
+              "headers": {
+                "description": "Optional HTTP headers to send with the SSE request",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["url"],
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
       },
       "description": "Model Control Protocol server configurations",
       "type": "object"


### PR DESCRIPTION
Support precise typing of MCP server configurations by conditionally enforcing stdio or sse server specific properties.

Stdio server properties:
- `command` (required)
- `args`
- `env`

SSE server properties:
- `url` (required)
- `headers`

Also added a `$schema` link in the README config example for visibility.