### PR TITLE
Implement custom commands

### DIFF
--- a/internal/tui/components/dialog/custom_commands.go
+++ b/internal/tui/components/dialog/custom_commands.go
@@ -1,0 +1,103 @@
+package dialog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/opencode-ai/opencode/internal/config"
+	"github.com/opencode-ai/opencode/internal/tui/util"
+)
+
+// CustomCommandPrefix is the prefix used for custom commands loaded from files
+const CustomCommandPrefix = "user:"
+
+// LoadCustomCommands loads custom commands from the data directory
+func LoadCustomCommands() ([]Command, error) {
+	cfg := config.Get()
+	if cfg == nil {
+		return nil, fmt.Errorf("config not loaded")
+	}
+
+	dataDir := cfg.Data.Directory
+	commandsDir := filepath.Join(dataDir, "commands")
+
+	// Check if the commands directory exists
+	if _, err := os.Stat(commandsDir); os.IsNotExist(err) {
+		// Create the commands directory if it doesn't exist
+		if err := os.MkdirAll(commandsDir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create commands directory: %w", err)
+		}
+		// Return empty list since we just created the directory
+		return []Command{}, nil
+	}
+
+	var commands []Command
+
+	// Walk through the commands directory and load all .md files
+	err := filepath.Walk(commandsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Only process markdown files
+		if !strings.HasSuffix(strings.ToLower(info.Name()), ".md") {
+			return nil
+		}
+
+		// Read the file content
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read command file %s: %w", path, err)
+		}
+
+		// Get the command ID from the file name without the .md extension
+		commandID := strings.TrimSuffix(info.Name(), filepath.Ext(info.Name()))
+		
+		// Get relative path from commands directory
+		relPath, err := filepath.Rel(commandsDir, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path for %s: %w", path, err)
+		}
+		
+		// Create the command ID from the relative path
+		// Replace directory separators with colons
+		commandIDPath := strings.ReplaceAll(filepath.Dir(relPath), string(filepath.Separator), ":")
+		if commandIDPath != "." {
+			commandID = commandIDPath + ":" + commandID
+		}
+
+		// Create a command
+		command := Command{
+			ID:          CustomCommandPrefix + commandID,
+			Title:       commandID,
+			Description: fmt.Sprintf("Custom command from %s", relPath),
+			Handler: func(cmd Command) tea.Cmd {
+				return util.CmdHandler(CommandRunCustomMsg{
+					Content: string(content),
+				})
+			},
+		}
+
+		commands = append(commands, command)
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to load custom commands: %w", err)
+	}
+
+	return commands, nil
+}
+
+// CommandRunCustomMsg is sent when a custom command is executed
+type CommandRunCustomMsg struct {
+	Content string
+}

--- a/internal/tui/page/chat.go
+++ b/internal/tui/page/chat.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opencode-ai/opencode/internal/app"
 	"github.com/opencode-ai/opencode/internal/session"
 	"github.com/opencode-ai/opencode/internal/tui/components/chat"
+	"github.com/opencode-ai/opencode/internal/tui/components/dialog"
 	"github.com/opencode-ai/opencode/internal/tui/layout"
 	"github.com/opencode-ai/opencode/internal/tui/util"
 )
@@ -53,6 +54,12 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, cmd)
 	case chat.SendMsg:
 		cmd := p.sendMessage(msg.Text)
+		if cmd != nil {
+			return p, cmd
+		}
+	case dialog.CommandRunCustomMsg:
+		// Handle custom command execution
+		cmd := p.sendMessage(msg.Content)
 		if cmd != nil {
 			return p, cmd
 		}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -672,5 +672,16 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules) or Copilot rules (
 			)
 		},
 	})
+	
+	// Load custom commands
+	customCommands, err := dialog.LoadCustomCommands()
+	if err != nil {
+		logging.Warn("Failed to load custom commands", "error", err)
+	} else {
+		for _, cmd := range customCommands {
+			model.RegisterCommand(cmd)
+		}
+	}
+	
 	return model
 }


### PR DESCRIPTION
Users can create custom commands by adding .md files to their configured `<data_dir>/commands` dir (default is `.opencode/commands`). They can then open the command dialog as normal with `cttrl+k` and select one of the custom commands.

Custom commands are simply prompts and work similar to custom slash commands in Claude Code
ref: https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#create-custom-slash-commands