### PR TITLE
Fix filepicker manual input

### DIFF
--- a/internal/tui/components/dialog/filepicker.go
+++ b/internal/tui/components/dialog/filepicker.go
@@ -163,23 +163,35 @@ func (f *filepickerCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return f, cmd
 				}
 				isPathDir = fileInfo.IsDir()
+				if isPathDir {
+					newWorkingDir := DirNode{parent: f.cwdDetails, directory: path}
+					f.cwdDetails.child = &newWorkingDir
+					f.cwdDetails = f.cwdDetails.child
+					f.cursorChain = f.cursorChain.Push(f.cursor)
+					f.dirs = readDir(f.cwdDetails.directory, false)
+					f.cursor = 0
+					f.cwd.SetValue(f.cwdDetails.directory)
+					f.getCurrentFileBelowCursor()
+				} else {
+					f.selectedFile = path
+					return f.addAttachmentToMessage()
+				}
 			} else {
 				path = filepath.Join(f.cwdDetails.directory, "/", f.dirs[f.cursor].Name())
 				isPathDir = f.dirs[f.cursor].IsDir()
-			}
-			if isPathDir {
-				path := filepath.Join(f.cwdDetails.directory, "/", f.dirs[f.cursor].Name())
-				newWorkingDir := DirNode{parent: f.cwdDetails, directory: path}
-				f.cwdDetails.child = &newWorkingDir
-				f.cwdDetails = f.cwdDetails.child
-				f.cursorChain = f.cursorChain.Push(f.cursor)
-				f.dirs = readDir(f.cwdDetails.directory, false)
-				f.cursor = 0
-				f.cwd.SetValue(f.cwdDetails.directory)
-				f.getCurrentFileBelowCursor()
-			} else {
-				f.selectedFile = path
-				return f.addAttachmentToMessage()
+				if isPathDir {
+					newWorkingDir := DirNode{parent: f.cwdDetails, directory: path}
+					f.cwdDetails.child = &newWorkingDir
+					f.cwdDetails = f.cwdDetails.child
+					f.cursorChain = f.cursorChain.Push(f.cursor)
+					f.dirs = readDir(f.cwdDetails.directory, false)
+					f.cursor = 0
+					f.cwd.SetValue(f.cwdDetails.directory)
+					f.getCurrentFileBelowCursor()
+				} else {
+					f.selectedFile = path
+					return f.addAttachmentToMessage()
+				}
 			}
 		case key.Matches(msg, filePickerKeyMap.Esc):
 			if !f.cwd.Focused() {
@@ -228,37 +240,35 @@ func (f *filepickerCmp) addAttachmentToMessage() (tea.Model, tea.Cmd) {
 		logging.ErrorPersist(fmt.Sprintf("Model %s doesn't support attachments", modeInfo.Name))
 		return f, nil
 	}
-	if isExtSupported(f.dirs[f.cursor].Name()) {
-		f.selectedFile = f.dirs[f.cursor].Name()
-		selectedFilePath := filepath.Join(f.cwdDetails.directory, "/", f.selectedFile)
-		isFileLarge, err := image.ValidateFileSize(selectedFilePath, maxAttachmentSize)
-		if err != nil {
-			logging.ErrorPersist("unable to read the image")
-			return f, nil
-		}
-		if isFileLarge {
-			logging.ErrorPersist("file too large, max 5MB")
-			return f, nil
-		}
 
-		content, err := os.ReadFile(selectedFilePath)
-		if err != nil {
-			logging.ErrorPersist("Unable read selected file")
-			return f, nil
-		}
-
-		mimeBufferSize := min(512, len(content))
-		mimeType := http.DetectContentType(content[:mimeBufferSize])
-		fileName := f.selectedFile
-		attachment := message.Attachment{FilePath: selectedFilePath, FileName: fileName, MimeType: mimeType, Content: content}
-		f.selectedFile = ""
-		return f, util.CmdHandler(AttachmentAddedMsg{attachment})
-	}
-	if !isExtSupported(f.selectedFile) {
+	selectedFilePath := f.selectedFile
+	if !isExtSupported(selectedFilePath) {
 		logging.ErrorPersist("Unsupported file")
 		return f, nil
 	}
-	return f, nil
+
+	isFileLarge, err := image.ValidateFileSize(selectedFilePath, maxAttachmentSize)
+	if err != nil {
+		logging.ErrorPersist("unable to read the image")
+		return f, nil
+	}
+	if isFileLarge {
+		logging.ErrorPersist("file too large, max 5MB")
+		return f, nil
+	}
+
+	content, err := os.ReadFile(selectedFilePath)
+	if err != nil {
+		logging.ErrorPersist("Unable read selected file")
+		return f, nil
+	}
+
+	mimeBufferSize := min(512, len(content))
+	mimeType := http.DetectContentType(content[:mimeBufferSize])
+	fileName := filepath.Base(selectedFilePath)
+	attachment := message.Attachment{FilePath: selectedFilePath, FileName: fileName, MimeType: mimeType, Content: content}
+	f.selectedFile = ""
+	return f, util.CmdHandler(AttachmentAddedMsg{attachment})
 }
 
 func (f *filepickerCmp) View() string {

--- a/internal/tui/components/dialog/filepicker.go
+++ b/internal/tui/components/dialog/filepicker.go
@@ -127,6 +127,9 @@ func (f *filepickerCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		f.cursor = 0
 		f.getCurrentFileBelowCursor()
 	case tea.KeyMsg:
+		if f.cwd.Focused() {
+			f.cwd, cmd = f.cwd.Update(msg)
+		}
 		switch {
 		case key.Matches(msg, filePickerKeyMap.InsertCWD):
 			f.cwd.Focus()
@@ -215,9 +218,6 @@ func (f *filepickerCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			f.cursor = 0
 			f.getCurrentFileBelowCursor()
 		}
-	}
-	if f.cwd.Focused() {
-		f.cwd, cmd = f.cwd.Update(msg)
 	}
 	return f, cmd
 }


### PR DESCRIPTION
two things i noticed when i was playing around with the new feat of sending images:
1. when you are in trying to manually type our the file name, you were not able to type `i`
2. if you were manually typing out the file name and you tried to press enter to attach the image, it would try to submit the current item you are highlighting over on the directory and not the manually inputted file.