### PR TITLE
Config fix correcting loose viper string check, default model now set…

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,7 +260,7 @@ func setProviderDefaults() {
 	// 7. Azure
 
 	// Anthropic configuration
-	if viper.Get("providers.anthropic.apiKey") != "" {
+	if key := viper.GetString("providers.anthropic.apiKey"); strings.TrimSpace(key) != "" {
 		viper.SetDefault("agents.coder.model", models.Claude37Sonnet)
 		viper.SetDefault("agents.task.model", models.Claude37Sonnet)
 		viper.SetDefault("agents.title.model", models.Claude37Sonnet)
@@ -268,7 +268,7 @@ func setProviderDefaults() {
 	}
 
 	// OpenAI configuration
-	if viper.Get("providers.openai.apiKey") != "" {
+	if key := viper.GetString("providers.openai.apiKey"); strings.TrimSpace(key) != "" {
 		viper.SetDefault("agents.coder.model", models.GPT41)
 		viper.SetDefault("agents.task.model", models.GPT41Mini)
 		viper.SetDefault("agents.title.model", models.GPT41Mini)
@@ -276,7 +276,7 @@ func setProviderDefaults() {
 	}
 
 	// Google Gemini configuration
-	if viper.Get("providers.google.gemini.apiKey") != "" {
+	if key := viper.GetString("providers.gemini.apiKey"); strings.TrimSpace(key) != "" {
 		viper.SetDefault("agents.coder.model", models.Gemini25)
 		viper.SetDefault("agents.task.model", models.Gemini25Flash)
 		viper.SetDefault("agents.title.model", models.Gemini25Flash)
@@ -284,7 +284,7 @@ func setProviderDefaults() {
 	}
 
 	// Groq configuration
-	if viper.Get("providers.groq.apiKey") != "" {
+	if key := viper.GetString("providers.groq.apiKey"); strings.TrimSpace(key) != "" {
 		viper.SetDefault("agents.coder.model", models.QWENQwq)
 		viper.SetDefault("agents.task.model", models.QWENQwq)
 		viper.SetDefault("agents.title.model", models.QWENQwq)
@@ -292,14 +292,15 @@ func setProviderDefaults() {
 	}
 
 	// OpenRouter configuration
-	if viper.Get("providers.openrouter.apiKey") != "" {
+	if key := viper.GetString("providers.openrouter.apiKey"); strings.TrimSpace(key) != "" {
 		viper.SetDefault("agents.coder.model", models.OpenRouterClaude37Sonnet)
 		viper.SetDefault("agents.task.model", models.OpenRouterClaude37Sonnet)
 		viper.SetDefault("agents.title.model", models.OpenRouterClaude35Haiku)
 		return
 	}
 
-	if viper.Get("providers.xai.apiKey") != "" {
+	// XAI configuration
+	if key := viper.GetString("providers.xai.apiKey"); strings.TrimSpace(key) != "" {
 		viper.SetDefault("agents.coder.model", models.XAIGrok3Beta)
 		viper.SetDefault("agents.task.model", models.XAIGrok3Beta)
 		viper.SetDefault("agents.title.model", models.XAiGrok3MiniFastBeta)
@@ -314,6 +315,7 @@ func setProviderDefaults() {
 		return
 	}
 
+	// Azure OpenAI configuration
 	if os.Getenv("AZURE_OPENAI_ENDPOINT") != "" {
 		viper.SetDefault("agents.coder.model", models.AzureGPT41)
 		viper.SetDefault("agents.task.model", models.AzureGPT41Mini)


### PR DESCRIPTION
## What kind of change does this PR introduce?

[x ] Bugfix
[] Feature
[] Code update (local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:

## What is the current behavior?

If the user has no config file, and has only set their api key as an environment variable, Anthropic is _always_ being set as the default model. If you print out the viper config after setting OPENAI_API_KEY you will see this:

```
 {
  "$schema": "./opencode-schema.json",
  "agents": {
    "coder": {
      "model": "claude-3.7-sonnet"
    },
    "task": {
      "model": "claude-3.7-sonnet"
    },
    "title": {
      "model": "claude-3.7-sonnet"
    }
  },
```

If using an OpenAI api key, this results in the following error because the max_token size is defaulting to Claude's (see #140):
```
│Message:                                                                                                                                  │
│  POST "https://api.openai.com/v1/chat/completions": 400 Bad Request {                                                                    │
│      "message": "max_tokens is too large: 50000. This model supports at most 32768 completion tokens, whereas you provided 50000.",      │
│      "type": "invalid_request_error",                                                                                                    │
│      "param": "max_tokens",                                                                                                              │
│      "code": "invalid_value"                                                                                                             │
│    }                                                                                                                                     │
```

It is happening because in config.go, `viper.Get(...)` returns an interface{}, and comparing that to `""` is not reliable.

## What is the new behavior?

Using viper.GetString, models are now correctly set based on environment variable api keys and `max_tokens` is no longer set to 50000 by default.