### PR TITLE
Support global context paths by merging built-in defaults with user-specified paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ You can configure OpenCode using environment variables:
 }
 ```
 
+### Context Paths
+By default, OpenCode loads a set of built-in context files (e.g. `.github/copilot-instructions.md`, `.cursor/rules/`, `OPENCODE.md`, etc.) to provide additional guidance to the AI assistant. You can extend or override these by adding a `contextPaths` array to your configuration:
+```json
+{
+  "contextPaths": [
+    "docs/context.md",
+    "./project-instructions.md",
+    "/some/absolute/global-instructions.md"
+  ]
+}
+```
+Relative paths (those not starting with `/`) are resolved against the configured working directory, while absolute paths are used as-is. Duplicate entries are automatically removed.
+
+
 ## Supported AI Models
 
 OpenCode supports a variety of AI models from different providers:


### PR DESCRIPTION
This change adds first-class support for “global context paths” in OpenCode. Previously, OpenCode only loaded a fixed set of built-in context files. With this PR you can now append your own Markdown or instruction files—globally or per-project—while preserving the existing defaults.

What’s changed:
* Introduce `Config.ContextPaths []string` to hold the final list of context files.
* Add `processContextPaths()`
* Starts from the built-in `defaultContextPaths`
* Appends any `contextPaths` from your Viper config
 * Resolves relative paths against the configured working directory
* Leaves absolute paths untouched
* Deduplicates the final list
* Wire `processContextPaths()` into `Load()` so it runs after reading global & local configs, but before unmarshalling into `Config`.
* Provide a `ContextPaths()` helper to retrieve the normalized list at runtime.
* Update README with a **Context Paths** section showing how to configure and use this feature.