### PR TITLE
feat: Make shell configurable via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ You can configure OpenCode using environment variables:
 | `AZURE_OPENAI_ENDPOINT`    | For Azure OpenAI models                                |
 | `AZURE_OPENAI_API_KEY`     | For Azure OpenAI models (optional when using Entra ID) |
 | `AZURE_OPENAI_API_VERSION` | For Azure OpenAI models                                |
+| `SHELL`                    | Default shell to use (if not specified in config)      |
+
+### Shell Configuration
+
+OpenCode allows you to configure the shell used by the bash tool. By default, it uses the shell specified in the `SHELL` environment variable, or falls back to `/bin/bash` if not set.
+
+You can override this in your configuration file:
+
+```json
+{
+  "shell": {
+    "path": "/bin/zsh",
+    "args": ["-l"]
+  }
+}
+```
+
+This is useful if you want to use a different shell than your default system shell, or if you need to pass specific arguments to the shell.
 
 ### Configuration File Structure
 
@@ -134,6 +152,10 @@ You can configure OpenCode using environment variables:
       "model": "claude-3.7-sonnet",
       "maxTokens": 80
     }
+  },
+  "shell": {
+    "path": "/bin/bash",
+    "args": ["-l"]
   },
   "mcpServers": {
     "example": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,12 @@ type TUIConfig struct {
 	Theme string `json:"theme,omitempty"`
 }
 
+// ShellConfig defines the configuration for the shell used by the bash tool.
+type ShellConfig struct {
+	Path string   `json:"path,omitempty"`
+	Args []string `json:"args,omitempty"`
+}
+
 // Config is the main configuration structure for the application.
 type Config struct {
 	Data         Data                              `json:"data"`
@@ -85,6 +91,7 @@ type Config struct {
 	DebugLSP     bool                              `json:"debugLSP,omitempty"`
 	ContextPaths []string                          `json:"contextPaths,omitempty"`
 	TUI          TUIConfig                         `json:"tui"`
+	Shell        ShellConfig                       `json:"shell,omitempty"`
 	AutoCompact  bool                              `json:"autoCompact,omitempty"`
 }
 
@@ -216,6 +223,14 @@ func setDefaults(debug bool) {
 	viper.SetDefault("contextPaths", defaultContextPaths)
 	viper.SetDefault("tui.theme", "opencode")
 	viper.SetDefault("autoCompact", true)
+
+	// Set default shell from environment or fallback to /bin/bash
+	shellPath := os.Getenv("SHELL")
+	if shellPath == "" {
+		shellPath = "/bin/bash"
+	}
+	viper.SetDefault("shell.path", shellPath)
+	viper.SetDefault("shell.args", []string{"-l"})
 
 	if debug {
 		viper.SetDefault("debug", true)


### PR DESCRIPTION
## Summary
- Add ability to configure the shell used by the bash tool via the config file
- Default to $SHELL environment variable if not specified in config
- Fall back to /bin/bash if neither config nor environment variable is set

## Test plan
- Verify that shell configuration works with different shells
- Verify that shell arguments can be customized
- Verify backward compatibility with existing behavior

🤖 Generated with opencode