### PR TITLE
docs: fix typos

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,7 @@ const (
 type Agent struct {
 	Model           models.ModelID `json:"model"`
 	MaxTokens       int64          `json:"maxTokens"`
-	ReasoningEffort string         `json:"reasoningEffort"` // For openai models low,medium,heigh
+	ReasoningEffort string         `json:"reasoningEffort"` // For openai models low,medium,height
 }
 
 // Provider defines configuration for an LLM provider.

--- a/internal/history/file.go
+++ b/internal/history/file.go
@@ -28,7 +28,7 @@ type File struct {
 }
 
 type Service interface {
-	pubsub.Suscriber[File]
+	pubsub.Subscriber[File]
 	Create(ctx context.Context, sessionID, path, content string) (File, error)
 	CreateVersion(ctx context.Context, sessionID, path, content string) (File, error)
 	Get(ctx context.Context, id string) (File, error)

--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -46,7 +46,7 @@ type AgentEvent struct {
 }
 
 type Service interface {
-	pubsub.Suscriber[AgentEvent]
+	pubsub.Subscriber[AgentEvent]
 	Model() models.Model
 	Run(ctx context.Context, sessionID string, content string, attachments ...message.Attachment) (<-chan AgentEvent, error)
 	Cancel(sessionID string)
@@ -251,15 +251,15 @@ func (a *agent) processGeneration(ctx context.Context, sessionID, content string
 		return a.err(fmt.Errorf("failed to get session: %w", err))
 	}
 	if session.SummaryMessageID != "" {
-		summaryMsgInex := -1
+		summaryMsgIndex := -1
 		for i, msg := range msgs {
 			if msg.ID == session.SummaryMessageID {
-				summaryMsgInex = i
+				summaryMsgIndex = i
 				break
 			}
 		}
-		if summaryMsgInex != -1 {
-			msgs = msgs[summaryMsgInex:]
+		if summaryMsgIndex != -1 {
+			msgs = msgs[summaryMsgIndex:]
 			msgs[0].Role = message.User
 		}
 	}
@@ -422,8 +422,8 @@ out:
 	return assistantMsg, &msg, err
 }
 
-func (a *agent) finishMessage(ctx context.Context, msg *message.Message, finishReson message.FinishReason) {
-	msg.AddFinish(finishReson)
+func (a *agent) finishMessage(ctx context.Context, msg *message.Message, finishReason message.FinishReason) {
+	msg.AddFinish(finishReason)
 	_ = a.messages.Update(ctx, *msg)
 }
 

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -200,7 +200,7 @@ func (a *anthropicClient) preparedMessages(messages []anthropic.MessageParam, to
 	}
 }
 
-func (a *anthropicClient) send(ctx context.Context, messages []message.Message, tools []tools.BaseTool) (resposne *ProviderResponse, err error) {
+func (a *anthropicClient) send(ctx context.Context, messages []message.Message, tools []tools.BaseTool) (response *ProviderResponse, err error) {
 	preparedMessages := a.preparedMessages(a.convertMessages(messages), a.convertTools(tools))
 	cfg := config.Get()
 	if cfg.Debug {

--- a/internal/logging/message.go
+++ b/internal/logging/message.go
@@ -9,8 +9,8 @@ type LogMessage struct {
 	ID          string
 	Time        time.Time
 	Level       string
-	Persist     bool          // used when we want to show the mesage in the status bar
-	PersistTime time.Duration // used when we want to show the mesage in the status bar
+	Persist     bool          // used when we want to show the message in the status bar
+	PersistTime time.Duration // used when we want to show the message in the status bar
 	Message     string        `json:"msg"`
 	Attributes  []Attr
 }

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -18,7 +18,7 @@ func HandleWorkspaceConfiguration(params json.RawMessage) (any, error) {
 func HandleRegisterCapability(params json.RawMessage) (any, error) {
 	var registerParams protocol.RegistrationParams
 	if err := json.Unmarshal(params, &registerParams); err != nil {
-		logging.Error("Error unmarshaling registration params", "error", err)
+		logging.Error("Error unmarshalling registration params", "error", err)
 		return nil, err
 	}
 
@@ -34,7 +34,7 @@ func HandleRegisterCapability(params json.RawMessage) (any, error) {
 
 			var options protocol.DidChangeWatchedFilesRegistrationOptions
 			if err := json.Unmarshal(optionsJSON, &options); err != nil {
-				logging.Error("Error unmarshaling registration options", "error", err)
+				logging.Error("Error unmarshalling registration options", "error", err)
 				continue
 			}
 
@@ -97,7 +97,7 @@ func HandleServerMessage(params json.RawMessage) {
 func HandleDiagnostics(client *Client, params json.RawMessage) {
 	var diagParams protocol.PublishDiagnosticsParams
 	if err := json.Unmarshal(params, &diagParams); err != nil {
-		logging.Error("Error unmarshaling diagnostics params", "error", err)
+		logging.Error("Error unmarshalling diagnostics params", "error", err)
 		return
 	}
 

--- a/internal/lsp/protocol/tsprotocol.go
+++ b/internal/lsp/protocol/tsprotocol.go
@@ -4988,7 +4988,7 @@ type SignatureHelp struct {
 	// range of `signatures` the value defaults to zero or is ignored if
 	// the `SignatureHelp` has no signatures.
 	//
-	// Whenever possible implementors should make an active decision about
+	// Whenever possible implementers should make an active decision about
 	// the active signature and shouldn't rely on a default value.
 	//
 	// In future version of the protocol this property might become

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -20,7 +20,7 @@ type CreateMessageParams struct {
 }
 
 type Service interface {
-	pubsub.Suscriber[Message]
+	pubsub.Subscriber[Message]
 	Create(ctx context.Context, sessionID string, params CreateMessageParams) (Message, error)
 	Update(ctx context.Context, message Message) error
 	Get(ctx context.Context, id string) (Message, error)

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -33,8 +33,8 @@ type PermissionRequest struct {
 }
 
 type Service interface {
-	pubsub.Suscriber[PermissionRequest]
-	GrantPersistant(permission PermissionRequest)
+	pubsub.Subscriber[PermissionRequest]
+	GrantPersistent(permission PermissionRequest)
 	Grant(permission PermissionRequest)
 	Deny(permission PermissionRequest)
 	Request(opts CreatePermissionRequest) bool
@@ -49,7 +49,7 @@ type permissionService struct {
 	autoApproveSessions []string
 }
 
-func (s *permissionService) GrantPersistant(permission PermissionRequest) {
+func (s *permissionService) GrantPersistent(permission PermissionRequest) {
 	respCh, ok := s.pendingRequests.Load(permission.ID)
 	if ok {
 		respCh.(chan bool) <- true

--- a/internal/pubsub/events.go
+++ b/internal/pubsub/events.go
@@ -8,7 +8,7 @@ const (
 	DeletedEvent EventType = "deleted"
 )
 
-type Suscriber[T any] interface {
+type Subscriber[T any] interface {
 	Subscribe(context.Context) <-chan Event[T]
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -23,7 +23,7 @@ type Session struct {
 }
 
 type Service interface {
-	pubsub.Suscriber[Session]
+	pubsub.Subscriber[Session]
 	Create(ctx context.Context, title string) (Session, error)
 	CreateTitleSession(ctx context.Context, parentSessionID string) (Session, error)
 	CreateTaskSession(ctx context.Context, toolCallID, parentSessionID, title string) (Session, error)

--- a/internal/tui/components/chat/editor.go
+++ b/internal/tui/components/chat/editor.go
@@ -38,7 +38,7 @@ type EditorKeyMaps struct {
 	OpenEditor key.Binding
 }
 
-type bluredEditorKeyMaps struct {
+type blurredEditorKeyMaps struct {
 	Send       key.Binding
 	Focus      key.Binding
 	OpenEditor key.Binding
@@ -71,7 +71,7 @@ var DeleteKeyMaps = DeleteAttachmentKeyMaps{
 	),
 	DeleteAllAttachments: key.NewBinding(
 		key.WithKeys("r"),
-		key.WithHelp("ctrl+r+r", "delete all attchments"),
+		key.WithHelp("ctrl+r+r", "delete all attachments"),
 	),
 }
 
@@ -198,7 +198,7 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.deleteMode = false
 			return m, nil
 		}
-		// Hanlde Enter key
+		// Handle Enter key
 		if m.textarea.Focused() && key.Matches(msg, editorMaps.Send) {
 			value := m.textarea.Value()
 			if len(value) > 0 && value[len(value)-1] == '\\' {

--- a/internal/tui/components/core/status.go
+++ b/internal/tui/components/core/status.go
@@ -143,12 +143,12 @@ func (m statusCmp) View() string {
 		Background(t.BackgroundDarker()).
 		Render(m.projectDiagnostics())
 
-	availableWidht := max(0, m.width-lipgloss.Width(helpWidget)-lipgloss.Width(m.model())-lipgloss.Width(diagnostics)-tokenInfoWidth)
+	availableWidth := max(0, m.width-lipgloss.Width(helpWidget)-lipgloss.Width(m.model())-lipgloss.Width(diagnostics)-tokenInfoWidth)
 
 	if m.info.Msg != "" {
 		infoStyle := styles.Padded().
 			Foreground(t.Background()).
-			Width(availableWidht)
+			Width(availableWidth)
 
 		switch m.info.Type {
 		case util.InfoTypeInfo:
@@ -159,7 +159,7 @@ func (m statusCmp) View() string {
 			infoStyle = infoStyle.Background(t.Error())
 		}
 
-		infoWidth := availableWidht - 10
+		infoWidth := availableWidth - 10
 		// Truncate message if it's longer than available width
 		msg := m.info.Msg
 		if len(msg) > infoWidth && infoWidth > 0 {
@@ -170,7 +170,7 @@ func (m statusCmp) View() string {
 		status += styles.Padded().
 			Foreground(t.Text()).
 			Background(t.BackgroundSecondary()).
-			Width(availableWidht).
+			Width(availableWidth).
 			Render("")
 	}
 

--- a/internal/tui/components/logs/table.go
+++ b/internal/tui/components/logs/table.go
@@ -76,12 +76,12 @@ func (i *tableCmp) GetSize() (int, int) {
 func (i *tableCmp) SetSize(width int, height int) tea.Cmd {
 	i.table.SetWidth(width)
 	i.table.SetHeight(height)
-	cloumns := i.table.Columns()
-	for i, col := range cloumns {
-		col.Width = (width / len(cloumns)) - 2
-		cloumns[i] = col
+	columns := i.table.Columns()
+	for i, col := range columns {
+		col.Width = (width / len(columns)) - 2
+		columns[i] = col
 	}
-	i.table.SetColumns(cloumns)
+	i.table.SetColumns(columns)
 	return nil
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -281,7 +281,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case dialog.PermissionAllow:
 			a.app.Permissions.Grant(msg.Permission)
 		case dialog.PermissionAllowForSession:
-			a.app.Permissions.GrantPersistant(msg.Permission)
+			a.app.Permissions.GrantPersistent(msg.Permission)
 		case dialog.PermissionDeny:
 			a.app.Permissions.Deny(msg.Permission)
 		}


### PR DESCRIPTION
Found via `codespell -L te` and `typos --hidden --format brief`