### PR TITLE
feat(vertexai): update Gemini model versions and add new preview models

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -352,10 +352,10 @@ func setProviderDefaults() {
 
 	// Google Cloud VertexAI configuration
 	if hasVertexAICredentials() {
-		viper.SetDefault("agents.coder.model", models.VertexAIGemini25)
-		viper.SetDefault("agents.summarizer.model", models.VertexAIGemini25)
-		viper.SetDefault("agents.task.model", models.VertexAIGemini25Flash)
-		viper.SetDefault("agents.title.model", models.VertexAIGemini25Flash)
+		viper.SetDefault("agents.coder.model", models.VertexAIGemini25ProPreview0605)
+		viper.SetDefault("agents.summarizer.model", models.VertexAIGemini25ProPreview0605)
+		viper.SetDefault("agents.task.model", models.VertexAIGemini25FlashPreview520)
+		viper.SetDefault("agents.title.model", models.VertexAIGemini25FlashPreview520)
 		return
 	}
 }
@@ -750,10 +750,10 @@ func setDefaultModelForAgent(agent AgentName) bool {
 		maxTokens := int64(5000)
 
 		if agent == AgentTitle {
-			model = models.VertexAIGemini25Flash
+			model = models.VertexAIGemini25FlashPreview520
 			maxTokens = 80
 		} else {
-			model = models.VertexAIGemini25
+			model = models.VertexAIGemini25ProPreview0605
 		}
 
 		cfg.Agents[agent] = Agent{

--- a/internal/llm/models/vertexai.go
+++ b/internal/llm/models/vertexai.go
@@ -4,14 +4,29 @@ const (
 	ProviderVertexAI ModelProvider = "vertexai"
 
 	// Models
-	VertexAIGemini25Flash ModelID = "vertexai.gemini-2.5-flash"
-	VertexAIGemini25      ModelID = "vertexai.gemini-2.5"
+	VertexAIGemini25FlashPreview520 ModelID = "vertexai.gemini-2.5-flash-preview-05-20"
+	VertexAIGemini25FlashPreview417 ModelID = "vertexai.gemini-2.5-flash-preview-04-17"
+	VertexAIGemini25ProPreview0605  ModelID = "vertexai.gemini-2.5-pro-preview-06-05"
+	VertexAIGemini25ProPreview0506  ModelID = "vertexai.gemini-2.5-pro-preview-05-06"
 )
 
 var VertexAIGeminiModels = map[ModelID]Model{
-	VertexAIGemini25Flash: {
-		ID:                  VertexAIGemini25Flash,
-		Name:                "VertexAI: Gemini 2.5 Flash",
+	VertexAIGemini25FlashPreview520: {
+		ID:                  VertexAIGemini25FlashPreview520,
+		Name:                "VertexAI: Gemini 2.5 Flash Preview (05-20)",
+		Provider:            ProviderVertexAI,
+		APIModel:            "gemini-2.5-flash-preview-05-20",
+		CostPer1MIn:         GeminiModels[Gemini25Flash].CostPer1MIn,
+		CostPer1MInCached:   GeminiModels[Gemini25Flash].CostPer1MInCached,
+		CostPer1MOut:        GeminiModels[Gemini25Flash].CostPer1MOut,
+		CostPer1MOutCached:  GeminiModels[Gemini25Flash].CostPer1MOutCached,
+		ContextWindow:       GeminiModels[Gemini25Flash].ContextWindow,
+		DefaultMaxTokens:    GeminiModels[Gemini25Flash].DefaultMaxTokens,
+		SupportsAttachments: true,
+	},
+	VertexAIGemini25FlashPreview417: {
+		ID:                  VertexAIGemini25FlashPreview417,
+		Name:                "VertexAI: Gemini 2.5 Flash Preview (04-17)",
 		Provider:            ProviderVertexAI,
 		APIModel:            "gemini-2.5-flash-preview-04-17",
 		CostPer1MIn:         GeminiModels[Gemini25Flash].CostPer1MIn,
@@ -22,11 +37,24 @@ var VertexAIGeminiModels = map[ModelID]Model{
 		DefaultMaxTokens:    GeminiModels[Gemini25Flash].DefaultMaxTokens,
 		SupportsAttachments: true,
 	},
-	VertexAIGemini25: {
-		ID:                  VertexAIGemini25,
-		Name:                "VertexAI: Gemini 2.5 Pro",
+	VertexAIGemini25ProPreview0605: {
+		ID:                  VertexAIGemini25ProPreview0605,
+		Name:                "VertexAI: Gemini 2.5 Pro Preview (06-05)",
 		Provider:            ProviderVertexAI,
-		APIModel:            "gemini-2.5-pro-preview-03-25",
+		APIModel:            "gemini-2.5-pro-preview-06-05",
+		CostPer1MIn:         GeminiModels[Gemini25].CostPer1MIn,
+		CostPer1MInCached:   GeminiModels[Gemini25].CostPer1MInCached,
+		CostPer1MOut:        GeminiModels[Gemini25].CostPer1MOut,
+		CostPer1MOutCached:  GeminiModels[Gemini25].CostPer1MOutCached,
+		ContextWindow:       GeminiModels[Gemini25].ContextWindow,
+		DefaultMaxTokens:    GeminiModels[Gemini25].DefaultMaxTokens,
+		SupportsAttachments: true,
+	},
+	VertexAIGemini25ProPreview0506: {
+		ID:                  VertexAIGemini25ProPreview0506,
+		Name:                "VertexAI: Gemini 2.5 Pro Preview (05-06)",
+		Provider:            ProviderVertexAI,
+		APIModel:            "gemini-2.5-pro-preview-05-06",
 		CostPer1MIn:         GeminiModels[Gemini25].CostPer1MIn,
 		CostPer1MInCached:   GeminiModels[Gemini25].CostPer1MInCached,
 		CostPer1MOut:        GeminiModels[Gemini25].CostPer1MOut,


### PR DESCRIPTION
- Add support for latest Gemini 2.5 Pro Preview (06-05) model
- Add support for Gemini 2.5 Flash Preview (05-20) model
- Add support for older preview models (05-06, 04-17) for backward compatibility
- Update default model selections in config to use the latest preview versions
- Replace generic model IDs with version-specific ones for better tracking