### PR TITLE
feat: Add ability to hide and show the sidebar

### DIFF
--- a/internal/tui/bindings/bindings.go
+++ b/internal/tui/bindings/bindings.go
@@ -1,0 +1,20 @@
+package bindings
+
+import "github.com/charmbracelet/bubbles/key"
+
+type Bindings interface {
+	BindingKeys() []key.Binding
+}
+
+func KeyMapToSlice(km any) []key.Binding {
+	switch km := km.(type) {
+	case map[string]key.Binding:
+		bindings := make([]key.Binding, 0, len(km))
+		for _, v := range km {
+			bindings = append(bindings, v)
+		}
+		return bindings
+	default:
+		return nil
+	}
+}

--- a/internal/tui/components/chat/sidebar.go
+++ b/internal/tui/components/chat/sidebar.go
@@ -15,12 +15,8 @@ import (
 	"github.com/opencode-ai/opencode/internal/session"
 	"github.com/opencode-ai/opencode/internal/tui/styles"
 	"github.com/opencode-ai/opencode/internal/tui/theme"
+	"github.com/opencode-ai/opencode/internal/tui/events"
 )
-
-type ToggleSidebarMsg struct{}
-
-func (t ToggleSidebarMsg) ToggleSidebar() {}
-
 
 type sidebarCmp struct {
 	width, height int
@@ -64,7 +60,7 @@ func (m *sidebarCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ctx := context.Background()
 			m.loadModifiedFiles(ctx)
 		}
-	case ToggleSidebarMsg:
+	case events.ToggleSidebarMsg:
 		m.hidden = !m.hidden
 	case pubsub.Event[session.Session]:
 		if msg.Type == pubsub.UpdatedEvent {

--- a/internal/tui/components/chat/sidebar.go
+++ b/internal/tui/components/chat/sidebar.go
@@ -17,6 +17,11 @@ import (
 	"github.com/opencode-ai/opencode/internal/tui/theme"
 )
 
+type ToggleSidebarMsg struct{}
+
+func (t ToggleSidebarMsg) ToggleSidebar() {}
+
+
 type sidebarCmp struct {
 	width, height int
 	session       session.Session
@@ -25,6 +30,7 @@ type sidebarCmp struct {
 		additions int
 		removals  int
 	}
+	hidden bool
 }
 
 func (m *sidebarCmp) Init() tea.Cmd {
@@ -58,6 +64,8 @@ func (m *sidebarCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ctx := context.Background()
 			m.loadModifiedFiles(ctx)
 		}
+	case ToggleSidebarMsg:
+		m.hidden = !m.hidden
 	case pubsub.Event[session.Session]:
 		if msg.Type == pubsub.UpdatedEvent {
 			if m.session.ID == msg.Payload.ID {
@@ -82,6 +90,9 @@ func (m *sidebarCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *sidebarCmp) View() string {
+	if m.hidden {
+		return ""
+	}
 	baseStyle := styles.BaseStyle()
 
 	return baseStyle.

--- a/internal/tui/components/dialog/commands.go
+++ b/internal/tui/components/dialog/commands.go
@@ -5,7 +5,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	utilComponents "github.com/opencode-ai/opencode/internal/tui/components/util"
-	"github.com/opencode-ai/opencode/internal/tui/layout"
+	"github.com/opencode-ai/opencode/internal/tui/bindings"
 	"github.com/opencode-ai/opencode/internal/tui/styles"
 	"github.com/opencode-ai/opencode/internal/tui/theme"
 	"github.com/opencode-ai/opencode/internal/tui/util"
@@ -57,7 +57,7 @@ type CloseCommandDialogMsg struct{}
 // CommandDialog interface for the command selection dialog
 type CommandDialog interface {
 	tea.Model
-	layout.Bindings
+	bindings.Bindings
 	SetCommands(commands []Command)
 }
 
@@ -159,7 +159,7 @@ func (c *commandDialogCmp) View() string {
 }
 
 func (c *commandDialogCmp) BindingKeys() []key.Binding {
-	return layout.KeyMapToSlice(commandKeys)
+	return bindings.KeyMapToSlice(commandKeys)
 }
 
 func (c *commandDialogCmp) SetCommands(commands []Command) {

--- a/internal/tui/components/util/simple-list.go
+++ b/internal/tui/components/util/simple-list.go
@@ -4,7 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/opencode-ai/opencode/internal/tui/layout"
+	"github.com/opencode-ai/opencode/internal/tui/bindings"
 	"github.com/opencode-ai/opencode/internal/tui/styles"
 	"github.com/opencode-ai/opencode/internal/tui/theme"
 )
@@ -15,7 +15,7 @@ type SimpleListItem interface {
 
 type SimpleList[T SimpleListItem] interface {
 	tea.Model
-	layout.Bindings
+	bindings.Bindings
 	SetMaxWidth(maxWidth int)
 	GetSelectedItem() (item T, idx int)
 	SetItems(items []T)
@@ -84,7 +84,7 @@ func (c *simpleListCmp[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (c *simpleListCmp[T]) BindingKeys() []key.Binding {
-	return layout.KeyMapToSlice(simpleListKeys)
+	return bindings.KeyMapToSlice(simpleListKeys)
 }
 
 func (c *simpleListCmp[T]) GetSelectedItem() (T, int) {

--- a/internal/tui/events/events.go
+++ b/internal/tui/events/events.go
@@ -1,0 +1,6 @@
+
+package events
+
+type ToggleSidebarMsg struct{}
+
+func (t ToggleSidebarMsg) ToggleSidebar() {}

--- a/internal/tui/events/events.go
+++ b/internal/tui/events/events.go
@@ -1,4 +1,3 @@
-
 package events
 
 type ToggleSidebarMsg struct{}

--- a/internal/tui/layout/split.go
+++ b/internal/tui/layout/split.go
@@ -56,6 +56,18 @@ func (s *splitPaneLayout) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		return s, s.SetSize(msg.Width, msg.Height)
+	default:
+		// Check if the message is a ToggleSidebarMsg and forward it to the right panel
+		if s.rightPanel != nil {
+			if _, ok := msg.(interface{ ToggleSidebar() }); ok {
+				u, cmd := s.rightPanel.Update(msg)
+				s.rightPanel = u.(Container)
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				return s, tea.Batch(cmds...)
+			}
+		}
 	}
 
 	if s.rightPanel != nil {

--- a/internal/tui/page/chat.go
+++ b/internal/tui/page/chat.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencode-ai/opencode/internal/session"
 	"github.com/opencode-ai/opencode/internal/tui/components/chat"
 	"github.com/opencode-ai/opencode/internal/tui/components/dialog"
+	"github.com/opencode-ai/opencode/internal/tui/events"
 	"github.com/opencode-ai/opencode/internal/tui/layout"
 	"github.com/opencode-ai/opencode/internal/tui/util"
 )
@@ -124,7 +125,7 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return p, nil
 			}
 		case key.Matches(msg, keyMap.ToggleSidebar):
-			return p, util.CmdHandler(chat.ToggleSidebarMsg{})
+			return p, util.CmdHandler(events.ToggleSidebarMsg{})
 		}
 	}
 	if p.showCompletionDialog {

--- a/internal/tui/page/chat.go
+++ b/internal/tui/page/chat.go
@@ -33,6 +33,7 @@ type ChatKeyMap struct {
 	ShowCompletionDialog key.Binding
 	NewSession           key.Binding
 	Cancel               key.Binding
+	ToggleSidebar        key.Binding
 }
 
 var keyMap = ChatKeyMap{
@@ -47,6 +48,10 @@ var keyMap = ChatKeyMap{
 	Cancel: key.NewBinding(
 		key.WithKeys("esc"),
 		key.WithHelp("esc", "cancel"),
+	),
+	ToggleSidebar: key.NewBinding(
+		key.WithKeys("ctrl+b"),
+		key.WithHelp("ctrl+b", "toggle sidebar"),
 	),
 }
 
@@ -118,6 +123,8 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				p.app.CoderAgent.Cancel(p.session.ID)
 				return p, nil
 			}
+		case key.Matches(msg, keyMap.ToggleSidebar):
+			return p, util.CmdHandler(chat.ToggleSidebarMsg{})
 		}
 	}
 	if p.showCompletionDialog {


### PR DESCRIPTION
This pull request introduces the ability for users to hide and show the sidebar by pressing `ctrl+b`. This feature provides more screen real estate for the main chat view, which is especially useful on smaller screens or scoped tmux panes.

The implementation involves:

- Adding a `hidden` state to the `sidebarCmp` component.
- Creating a `ToggleSidebarMsg` to toggle the sidebar's visibility.
- Adding a keybinding (`ctrl+b`) to the chat page to dispatch the message.
- Modifying the `splitPaneLayout` to forward the message to the sidebar.
- Expand chat on hide

🤖 Generated with opencode