### PR TITLE
OpenAI baseUrl support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -629,6 +629,44 @@ func getProviderAPIKey(provider models.ModelProvider) string {
 	return ""
 }
 
+
+// GetOpenAIBaseURL gets the base URL override for OpenAI-compatible providers
+func GetOpenAIBaseURL() string {
+    return os.Getenv("OPENAI_BASE_URL")
+}
+
+// GetOpenAIModelOverride gets the model name override for OpenAI-compatible providers
+func GetOpenAIModelOverride() string {
+    return os.Getenv("OPENAI_MODEL_OVERRIDE")
+}
+
+// GetOpenAIReasoningEffort gets the reasoning effort level
+func GetOpenAIReasoningEffort() string {
+    effort := os.Getenv("OPENAI_REASONING_EFFORT")
+    if effort == "" {
+        return "medium" // default
+    }
+    return effort
+}
+
+// GetOpenAIExtraHeaders parses extra headers from environment
+func GetOpenAIExtraHeaders() map[string]string {
+    headersStr := os.Getenv("OPENAI_EXTRA_HEADERS")
+    if headersStr == "" {
+        return nil
+    }
+
+    headers := make(map[string]string)
+    pairs := strings.Split(headersStr, ",")
+    for _, pair := range pairs {
+        kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+        if len(kv) == 2 {
+            headers[kv[0]] = kv[1]
+        }
+    }
+    return headers
+}
+
 // setDefaultModelForAgent sets a default model for an agent based on available providers
 func setDefaultModelForAgent(agent AgentName) bool {
 	// Check providers in order of preference

--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -717,31 +717,12 @@ func createAgentProvider(agentName config.AgentName) (provider.Provider, error) 
 
     // Handle OpenAI and OpenAI-compatible providers
     if model.Provider == models.ProviderOpenAI || model.Provider == models.ProviderLocal && model.CanReason {
-        openAIOptions := []provider.OpenAIOption{
-            provider.WithReasoningEffort(agentConfig.ReasoningEffort),
-        }
-
-        // Add environment variable overrides for OpenAI-compatible providers
-        if baseURL := config.GetOpenAIBaseURL(); baseURL != "" {
-            openAIOptions = append(openAIOptions, provider.WithOpenAIBaseURL(baseURL))
-        }
-
-        if modelOverride := config.GetOpenAIModelOverride(); modelOverride != "" {
-            openAIOptions = append(openAIOptions, provider.WithOpenAIModelOverride(modelOverride))
-        }
-
-        if headers := config.GetOpenAIExtraHeaders(); headers != nil {
-            openAIOptions = append(openAIOptions, provider.WithOpenAIExtraHeaders(headers))
-        }
-
-        // Override reasoning effort from env var if provided
-        if envEffort := config.GetOpenAIReasoningEffort(); envEffort != "medium" {
-            // Replace the reasoning effort with env var value
-            openAIOptions[0] = provider.WithReasoningEffort(envEffort)
-        }
-
-        opts = append(opts, provider.WithOpenAIOptions(openAIOptions...))
-
+        opts = append(
+            opts,
+            provider.WithOpenAIOptions(
+                provider.WithReasoningEffort(agentConfig.ReasoningEffort),
+            ),
+        )
     } else if model.Provider == models.ProviderAnthropic && model.CanReason && agentName == config.AgentCoder {
         opts = append(
             opts,
@@ -750,7 +731,7 @@ func createAgentProvider(agentName config.AgentName) (provider.Provider, error) 
             ),
         )
     }
-
+	
     agentProvider, err := provider.NewProvider(
         model.Provider,
         opts...,
@@ -758,5 +739,6 @@ func createAgentProvider(agentName config.AgentName) (provider.Provider, error) 
     if err != nil {
         return nil, fmt.Errorf("could not create provider: %v", err)
     }
+
     return agentProvider, nil
 }

--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -688,55 +688,75 @@ func (a *agent) Summarize(ctx context.Context, sessionID string) error {
 }
 
 func createAgentProvider(agentName config.AgentName) (provider.Provider, error) {
-	cfg := config.Get()
-	agentConfig, ok := cfg.Agents[agentName]
-	if !ok {
-		return nil, fmt.Errorf("agent %s not found", agentName)
-	}
-	model, ok := models.SupportedModels[agentConfig.Model]
-	if !ok {
-		return nil, fmt.Errorf("model %s not supported", agentConfig.Model)
-	}
+    cfg := config.Get()
+    agentConfig, ok := cfg.Agents[agentName]
+    if !ok {
+        return nil, fmt.Errorf("agent %s not found", agentName)
+    }
+    model, ok := models.SupportedModels[agentConfig.Model]
+    if !ok {
+        return nil, fmt.Errorf("model %s not supported", agentConfig.Model)
+    }
+    providerCfg, ok := cfg.Providers[model.Provider]
+    if !ok {
+        return nil, fmt.Errorf("provider %s not supported", model.Provider)
+    }
+    if providerCfg.Disabled {
+        return nil, fmt.Errorf("provider %s is not enabled", model.Provider)
+    }
+    maxTokens := model.DefaultMaxTokens
+    if agentConfig.MaxTokens > 0 {
+        maxTokens = agentConfig.MaxTokens
+    }
+    opts := []provider.ProviderClientOption{
+        provider.WithAPIKey(providerCfg.APIKey),
+        provider.WithModel(model),
+        provider.WithSystemMessage(prompt.GetAgentPrompt(agentName, model.Provider)),
+        provider.WithMaxTokens(maxTokens),
+    }
 
-	providerCfg, ok := cfg.Providers[model.Provider]
-	if !ok {
-		return nil, fmt.Errorf("provider %s not supported", model.Provider)
-	}
-	if providerCfg.Disabled {
-		return nil, fmt.Errorf("provider %s is not enabled", model.Provider)
-	}
-	maxTokens := model.DefaultMaxTokens
-	if agentConfig.MaxTokens > 0 {
-		maxTokens = agentConfig.MaxTokens
-	}
-	opts := []provider.ProviderClientOption{
-		provider.WithAPIKey(providerCfg.APIKey),
-		provider.WithModel(model),
-		provider.WithSystemMessage(prompt.GetAgentPrompt(agentName, model.Provider)),
-		provider.WithMaxTokens(maxTokens),
-	}
-	if model.Provider == models.ProviderOpenAI || model.Provider == models.ProviderLocal && model.CanReason {
-		opts = append(
-			opts,
-			provider.WithOpenAIOptions(
-				provider.WithReasoningEffort(agentConfig.ReasoningEffort),
-			),
-		)
-	} else if model.Provider == models.ProviderAnthropic && model.CanReason && agentName == config.AgentCoder {
-		opts = append(
-			opts,
-			provider.WithAnthropicOptions(
-				provider.WithAnthropicShouldThinkFn(provider.DefaultShouldThinkFn),
-			),
-		)
-	}
-	agentProvider, err := provider.NewProvider(
-		model.Provider,
-		opts...,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("could not create provider: %v", err)
-	}
+    // Handle OpenAI and OpenAI-compatible providers
+    if model.Provider == models.ProviderOpenAI || model.Provider == models.ProviderLocal && model.CanReason {
+        openAIOptions := []provider.OpenAIOption{
+            provider.WithReasoningEffort(agentConfig.ReasoningEffort),
+        }
 
-	return agentProvider, nil
+        // Add environment variable overrides for OpenAI-compatible providers
+        if baseURL := config.GetOpenAIBaseURL(); baseURL != "" {
+            openAIOptions = append(openAIOptions, provider.WithOpenAIBaseURL(baseURL))
+        }
+
+        if modelOverride := config.GetOpenAIModelOverride(); modelOverride != "" {
+            openAIOptions = append(openAIOptions, provider.WithOpenAIModelOverride(modelOverride))
+        }
+
+        if headers := config.GetOpenAIExtraHeaders(); headers != nil {
+            openAIOptions = append(openAIOptions, provider.WithOpenAIExtraHeaders(headers))
+        }
+
+        // Override reasoning effort from env var if provided
+        if envEffort := config.GetOpenAIReasoningEffort(); envEffort != "medium" {
+            // Replace the reasoning effort with env var value
+            openAIOptions[0] = provider.WithReasoningEffort(envEffort)
+        }
+
+        opts = append(opts, provider.WithOpenAIOptions(openAIOptions...))
+
+    } else if model.Provider == models.ProviderAnthropic && model.CanReason && agentName == config.AgentCoder {
+        opts = append(
+            opts,
+            provider.WithAnthropicOptions(
+                provider.WithAnthropicShouldThinkFn(provider.DefaultShouldThinkFn),
+            ),
+        )
+    }
+
+    agentProvider, err := provider.NewProvider(
+        model.Provider,
+        opts...,
+    )
+    if err != nil {
+        return nil, fmt.Errorf("could not create provider: %v", err)
+    }
+    return agentProvider, nil
 }


### PR DESCRIPTION
Hi, awesome project! I had some trouble getting OpenAI API compat endpoints working, so I made some minimal changes to make it easier. This adds basic OpenAI-compatible provider support as a practical stopgap solution while you guys are discussing other methods. LiteLLM is the easy button and a great opensource project, fwiw!

Adds environment variable support for:
- OPENAI_BASE_URL - override base URL for compatible providers
- OPENAI_MODEL_OVERRIDE - override model name
- OPENAI_EXTRA_HEADERS - custom headers (key=value,key=value)
- OPENAI_REASONING_EFFORT - reasoning effort level

This allows users to immediately use any OpenAI API compatible endpoint like [LocalAI.io](https://localai.io/) without code changes.

Sorry if I mangled any Go, first time for everything.

Thanks for your efforts, much appreciated!