### PR TITLE
feat(tui): require double escape to cancel

### DIFF
--- a/internal/tui/layout/container.go
+++ b/internal/tui/layout/container.go
@@ -11,6 +11,7 @@ type Container interface {
 	tea.Model
 	Sizeable
 	Bindings
+	Model() tea.Model
 }
 type container struct {
 	width  int
@@ -119,6 +120,10 @@ func (c *container) BindingKeys() []key.Binding {
 		return b.BindingKeys()
 	}
 	return []key.Binding{}
+}
+
+func (c *container) Model() tea.Model {
+	return c.content
 }
 
 type ContainerOption func(*container)

--- a/internal/tui/page/chat.go
+++ b/internal/tui/page/chat.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"time"
+
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -27,7 +29,10 @@ type chatPage struct {
 	session              session.Session
 	completionDialog     dialog.CompletionDialog
 	showCompletionDialog bool
+	firstEsc             time.Time
 }
+
+type firstEscTimedOutMsg struct{}
 
 type ChatKeyMap struct {
 	ShowCompletionDialog key.Binding
@@ -104,7 +109,7 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, keyMap.ShowCompletionDialog):
 			p.showCompletionDialog = true
-			// Continue sending keys to layout->chat
+		// Continue sending keys to layout->chat
 		case key.Matches(msg, keyMap.NewSession):
 			p.session = session.Session{}
 			return p, tea.Batch(
@@ -112,13 +117,20 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				util.CmdHandler(chat.SessionClearedMsg{}),
 			)
 		case key.Matches(msg, keyMap.Cancel):
-			if p.session.ID != "" {
-				// Cancel the current session's generation process
-				// This allows users to interrupt long-running operations
-				p.app.CoderAgent.Cancel(p.session.ID)
-				return p, nil
+			if p.app.CoderAgent.IsBusy() {
+				if p.firstEsc.IsZero() {
+					p.firstEsc = time.Now()
+					cmds = append(cmds, tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+						return firstEscTimedOutMsg{}
+					}))
+				} else {
+					p.firstEsc = time.Time{}
+					p.app.CoderAgent.Cancel(p.session.ID)
+				}
 			}
 		}
+	case firstEscTimedOutMsg:
+		p.firstEsc = time.Time{}
 	}
 	if p.showCompletionDialog {
 		context, contextCmd := p.completionDialog.Update(msg)
@@ -130,6 +142,11 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if keyMsg.String() == "enter" {
 				return p, tea.Batch(cmds...)
 			}
+		}
+	}
+	if p.messages.Model() != nil {
+		if messagesCmp, ok := p.messages.Model().(*chat.MessagesCmp); ok {
+			messagesCmp.SetFirstEsc(p.firstEsc)
 		}
 	}
 


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/413da695-0f80-4959-a52c-25193957896b


This pull request introduces a confirmation step for canceling an ongoing agent operation. Users must now press the `esc` key twice in quick succession to cancel, preventing accidental cancellations.

The implementation involves:
- Adding a timeout to the `esc` key press in the chat page.
- Passing the `firstEsc` state down to the message list component to update the help message.
- Adding a `Model()` method to the `layout.Container` to allow the chat page to access the message list's model.

## Test plan

1. Run the application.
2. Start an agent operation.
3. Press `esc` once. The help message should change to "press esc again to cancel".
4. Wait for 2 seconds. The help message should revert to its original state.
5. Press `esc` twice in quick succession. The agent operation should be canceled.

🤖 Generated with opencode