### PR TITLE
Add Flake Dev Environment an Optional Package Output

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
+fi
+
+watch_file flake.nix
+watch_file flake.lock
+if ! use flake . --no-pure-eval
+then
+  echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to flake.nix and hit enter to try again." >&2
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ Thumbs.db
 # Binary output directory
 /bin/
 /dist/
+.direnv
+result
 
 # Local environment variables
 .env

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749776303,
+        "narHash": "sha256-OHibOvVwKqO1qvRg0r3agtd1EagW4THBcoWT7QGgcNo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6e7721e37bf00fa7ea44ac3cfc9d2411284ec3ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749194973,
+        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,147 @@
+{
+  description = "OpenCode - Terminal-based AI assistant for software development";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    treefmt-nix,
+    ...
+  }: let
+    supportedSystems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+  in {
+    packages = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in {
+      default = pkgs.buildGo124Module {
+        pname = "opencode";
+        version = "0.1.0";
+        src = self;
+        vendorHash = "sha256-Kcwd8deHug7BPDzmbdFqEfoArpXJb1JtBKuk+drdohM=";
+        doCheck = false;
+
+        ldflags = [
+          "-s"
+          "-w"
+        ];
+
+        meta = with pkgs.lib; {
+          description = "OpenCode - Terminal-based AI assistant for software development";
+          homepage = "https://github.com/opencode-ai/opencode";
+          license = licenses.mit;
+        };
+      };
+    });
+
+    devShells = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      scripts = {
+        gen = {
+          exec = ''go generate ./...'';
+          description = "Run code generation";
+        };
+        lint = {
+          exec = ''golangci-lint run'';
+          description = "Run Linting Steps for go files";
+        };
+        build = {
+          exec = ''go build -o opencode .'';
+          description = "Build the OpenCode CLI";
+        };
+        run = {
+          exec = ''go run .'';
+          description = "Run the OpenCode CLI";
+        };
+        tests = {
+          exec = ''go test ./...'';
+          description = "Run all go tests";
+        };
+      };
+
+      scriptPackages =
+        pkgs.lib.mapAttrs
+        (
+          name: script:
+            pkgs.writeShellApplication {
+              inherit name;
+              text = script.exec;
+              runtimeInputs = script.deps or [];
+            }
+        )
+        scripts;
+
+      buildWithSpecificGo = pkg: pkg.override {buildGoModule = pkgs.buildGo124Module;};
+    in {
+      default = pkgs.mkShell {
+        name = "opencode-dev";
+
+        packages = with pkgs;
+          [
+            # Nix tools
+            alejandra
+            nixd
+            statix
+            deadnix
+
+            # Go Tools
+            go_1_24
+            air
+            golangci-lint
+            gopls
+            (buildWithSpecificGo revive)
+            (buildWithSpecificGo golines)
+            (buildWithSpecificGo golangci-lint-langserver)
+            (buildWithSpecificGo gomarkdoc)
+            (buildWithSpecificGo gotests)
+            (buildWithSpecificGo gotools)
+            (buildWithSpecificGo reftools)
+            pprof
+            graphviz
+            goreleaser
+            cobra-cli
+
+            # CLI development tools
+            sqlite
+          ]
+          ++ builtins.attrValues scriptPackages;
+
+        shellHook = ''
+          export REPO_ROOT=$(git rev-parse --show-toplevel)
+          echo "OpenCode development environment loaded"
+          echo "Run 'build' to build the CLI"
+          echo "Run 'run' to start the OpenCode CLI"
+          echo "Run 'tests' to run all tests"
+        '';
+      };
+    });
+
+    # Runnable with: > nix fmt
+    formatter = forAllSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      treefmtModule = {
+        projectRootFile = "flake.nix";
+        programs = {
+          alejandra.enable = true; # Nix formatter
+          gofmt.enable = true; # Go formatter
+        };
+      };
+    in
+      treefmt-nix.lib.mkWrapper pkgs treefmtModule);
+  };
+}


### PR DESCRIPTION
TLDR;;
Added a flake.nix and lock file containing pinned dependencies for working on the project.

This pull request introduces Nix-based environment management for the project, including a development shell and build system configuration. The changes focus on setting up a reproducible development environment and defining build and formatting processes using Nix flakes.

### Environment setup:

* [`.envrc`](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R1-R10): Added support for `nix-direnv` to automatically load the development environment defined in `flake.nix`. This includes watching `flake.nix` and `flake.lock` for changes and providing feedback if the environment cannot be loaded.

### Nix flake configuration:

* `flake.nix`: Defined a Nix flake with the following features:
  - **Development shell**: Configured tools and scripts for Go development, including building, running, testing, and linting the project. Tools like `golangci-lint`, `gopls`, and `cobra-cli` are included.
  - **Build system**: Set up a Go-based build process using `buildGo124Module`, specifying metadata like project description, homepage, and license.
  - **Formatter**: Added a formatter configuration (`nix fmt`) with support for `alejandra` (Nix files) and `gofmt` (Go files).