### PR TITLE
feat: Add support for custom provider endpoints and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ This is useful if you want to use a different shell than your default system she
   "providers": {
     "openai": {
       "apiKey": "your-api-key",
+      "baseURL": "https://custom-openai-endpoint.com/v1",
+      "headers": {
+        "X-Custom-Header": "value"
+      },
       "disabled": false
     },
     "anthropic": {
@@ -143,6 +147,7 @@ This is useful if you want to use a different shell than your default system she
     },
     "groq": {
       "apiKey": "your-api-key",
+      "baseURL": "https://custom-groq-proxy.com/openai/v1",
       "disabled": false
     },
     "openrouter": {
@@ -185,6 +190,49 @@ This is useful if you want to use a different shell than your default system she
   "debug": false,
   "debugLSP": false,
   "autoCompact": true
+}
+```
+
+### Provider Configuration
+
+#### Custom Base URLs
+
+You can configure custom base URLs for providers that support it (OpenAI, Gemini, Groq, OpenRouter, XAI, Local). This is useful for:
+
+- Using proxy servers
+- Corporate API gateways
+- Self-hosted compatible endpoints
+- Alternative API endpoints
+
+Example configuration:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "apiKey": "your-api-key",
+      "baseURL": "https://your-openai-proxy.com/v1"
+    }
+  }
+}
+```
+
+#### Custom Headers
+
+You can also add custom headers to provider requests (currently supported for OpenAI-compatible providers and Gemini):
+
+```json
+{
+  "providers": {
+    "openai": {
+      "apiKey": "your-api-key",
+      "baseURL": "https://your-proxy.com/v1",
+      "headers": {
+        "X-Auth-Token": "additional-auth-token",
+        "X-Organization": "your-org"
+      }
+    }
+  }
 }
 ```
 

--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -715,20 +715,58 @@ func createAgentProvider(agentName config.AgentName) (provider.Provider, error) 
 		provider.WithSystemMessage(prompt.GetAgentPrompt(agentName, model.Provider)),
 		provider.WithMaxTokens(maxTokens),
 	}
-	if model.Provider == models.ProviderOpenAI || model.Provider == models.ProviderLocal && model.CanReason {
-		opts = append(
-			opts,
-			provider.WithOpenAIOptions(
-				provider.WithReasoningEffort(agentConfig.ReasoningEffort),
-			),
-		)
-	} else if model.Provider == models.ProviderAnthropic && model.CanReason && agentName == config.AgentCoder {
-		opts = append(
-			opts,
-			provider.WithAnthropicOptions(
-				provider.WithAnthropicShouldThinkFn(provider.DefaultShouldThinkFn),
-			),
-		)
+	
+	// Apply provider-specific options based on configuration
+	switch model.Provider {
+	case models.ProviderOpenAI, models.ProviderLocal, models.ProviderGROQ, models.ProviderOpenRouter, models.ProviderXAI:
+		openAIOpts := []provider.OpenAIOption{}
+		
+		// Add BaseURL if configured
+		if providerCfg.BaseURL != "" {
+			openAIOpts = append(openAIOpts, provider.WithOpenAIBaseURL(providerCfg.BaseURL))
+		}
+		
+		// Add Headers if configured
+		if len(providerCfg.Headers) > 0 {
+			openAIOpts = append(openAIOpts, provider.WithOpenAIExtraHeaders(providerCfg.Headers))
+		}
+		
+		// Add reasoning effort if applicable
+		if (model.Provider == models.ProviderOpenAI || model.Provider == models.ProviderLocal) && model.CanReason {
+			openAIOpts = append(openAIOpts, provider.WithReasoningEffort(agentConfig.ReasoningEffort))
+		}
+		
+		if len(openAIOpts) > 0 {
+			opts = append(opts, provider.WithOpenAIOptions(openAIOpts...))
+		}
+		
+	case models.ProviderAnthropic:
+		if model.CanReason && agentName == config.AgentCoder {
+			opts = append(
+				opts,
+				provider.WithAnthropicOptions(
+					provider.WithAnthropicShouldThinkFn(provider.DefaultShouldThinkFn),
+				),
+			)
+		}
+		// TODO: Add BaseURL support for Anthropic when available
+		
+	case models.ProviderGemini:
+		geminiOpts := []provider.GeminiOption{}
+		
+		// Add BaseURL if configured
+		if providerCfg.BaseURL != "" {
+			geminiOpts = append(geminiOpts, provider.WithGeminiBaseURL(providerCfg.BaseURL))
+		}
+		
+		// Add Headers if configured
+		if len(providerCfg.Headers) > 0 {
+			geminiOpts = append(geminiOpts, provider.WithGeminiExtraHeaders(providerCfg.Headers))
+		}
+		
+		if len(geminiOpts) > 0 {
+			opts = append(opts, provider.WithGeminiOptions(geminiOpts...))
+		}
 	}
 	agentProvider, err := provider.NewProvider(
 		model.Provider,


### PR DESCRIPTION
This commit introduces several enhancements for configuration flexibility and usability.

Users can now specify a custom `baseURL` and `headers` for API providers (e.g., OpenAI, Gemini, Groq). This enables routing requests through proxies, corporate gateways, or connecting to self-hosted, API-compatible services.

Additionally, two new command-line flags have been added:
- `--config`: Allows specifying a path to a custom JSON configuration file, overriding the default search behavior.
- `--prompt-file`: Enables loading a prompt from a markdown file, making it easier to run complex, multi-line prompts in non-interactive mode.

The README has been updated to document these new features.