### PR TITLE
Add GitHub Action for golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for merge_group events with only-new-issues
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        timeout-minutes: 15
+        with:
+          version: v2
+          only-new-issues: true
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Golangci-lint is a fast linters runner for Go.


```shell
golangci-lint

cmd/root.go:52:12: Error return value of `cmd.Help` is not checked (errcheck)
			cmd.Help()
			        ^
cmd/root.go:306:36: Error return value of `rootCmd.RegisterFlagCompletionFunc` is not checked (errcheck)
	rootCmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
	                                  ^
internal/app/lsp.go:45:18: Error return value of `lspClient.Close` is not checked (errcheck)
		lspClient.Close()
		               ^
internal/completions/files-folders.go:69:21: Error return value of `rgPipe.Close` is not checked (errcheck)
		defer rgPipe.Close()
		                  ^
internal/config/config.go:425:23: Error return value of `viper.MergeConfigMap` is not checked (errcheck)
		viper.MergeConfigMap(local.AllSettings())
		                    ^
internal/config/init.go:57:18: Error return value of `file.Close` is not checked (errcheck)
	defer file.Close()
	                ^
internal/db/connect.go:35:11: Error return value of `db.Close` is not checked (errcheck)
		db.Close()
		        ^
internal/history/file.go:124:15: Error return value of `tx.Rollback` is not checked (errcheck)
			tx.Rollback()
			           ^
internal/llm/agent/agent.go:286:22: Error return value of `a.messages.Update` is not checked (errcheck)
				a.messages.Update(context.Background(), agentMessage)
				                 ^
internal/llm/agent/mcp-tools.go:45:15: Error return value of `c.Close` is not checked (errcheck)
	defer c.Close()
	             ^
internal/llm/agent/mcp-tools.go:161:15: Error return value of `c.Close` is not checked (errcheck)
	defer c.Close()
	             ^
internal/llm/models/local.go:85:22: Error return value of `res.Body.Close` is not checked (errcheck)
	defer res.Body.Close()
	                    ^
internal/llm/prompt/prompt.go:76:21: Error return value of `filepath.WalkDir` is not checked (errcheck)
				filepath.WalkDir(filepath.Join(workDir, p), func(path string, d os.DirEntry, err error) error {
				                ^
internal/llm/tools/fetch.go:161:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
internal/llm/tools/grep.go:332:18: Error return value of `file.Close` is not checked (errcheck)
	defer file.Close()
	                ^
internal/llm/tools/ls_test.go:30:20: Error return value of `os.RemoveAll` is not checked (errcheck)
	defer os.RemoveAll(tempDir)
	                  ^
internal/llm/tools/ls_test.go:190:12: Error return value of `os.Chdir` is not checked (errcheck)
			os.Chdir(origWd)
			        ^
internal/llm/tools/ls_test.go:373:20: Error return value of `os.RemoveAll` is not checked (errcheck)
	defer os.RemoveAll(tempDir)
	                  ^
internal/llm/tools/shell/shell.go:158:12: Error return value of `os.Remove` is not checked (errcheck)
		os.Remove(stdoutFile)
		         ^
internal/llm/tools/shell/shell.go:159:12: Error return value of `os.Remove` is not checked (errcheck)
		os.Remove(stderrFile)
		         ^
internal/llm/tools/shell/shell.go:160:12: Error return value of `os.Remove` is not checked (errcheck)
		os.Remove(statusFile)
		         ^
internal/llm/tools/shell/shell.go:228:13: Error return value of `fmt.Sscanf` is not checked (errcheck)
		fmt.Sscanf(exitCodeStr, "%d", &exitCode)
		          ^
internal/llm/tools/shell/shell.go:260:14: Error return value of `fmt.Sscanf` is not checked (errcheck)
			fmt.Sscanf(pidStr, "%d", &pid)
			          ^
internal/llm/tools/shell/shell.go:264:17: Error return value of `proc.Signal` is not checked (errcheck)
					proc.Signal(syscall.SIGTERM)
					           ^
internal/llm/tools/shell/shell.go:298:15: Error return value of `s.stdin.Write` is not checked (errcheck)
	s.stdin.Write([]byte("exit\n"))
	             ^
internal/llm/tools/shell/shell.go:300:20: Error return value of `s.cmd.Process.Kill` is not checked (errcheck)
	s.cmd.Process.Kill()
	                  ^
internal/llm/tools/sourcegraph.go:227:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
internal/logging/logger.go:63:20: Error return value of `file.Close` is not checked (errcheck)
			defer file.Close()
			                ^
internal/logging/logger.go:66:15: Error return value of `fmt.Fprintf` is not checked (errcheck)
			fmt.Fprintf(file, "Panic in %s: %v\n\n", name, r)
			           ^
internal/logging/logger.go:67:15: Error return value of `fmt.Fprintf` is not checked (errcheck)
			fmt.Fprintf(file, "Time: %s\n\n", time.Now().Format(time.RFC3339))
			           ^
internal/logging/logger.go:68:15: Error return value of `fmt.Fprintf` is not checked (errcheck)
			fmt.Fprintf(file, "Stack Trace:\n%s\n", debug.Stack())
			           ^
internal/lsp/watcher/watcher.go:332:21: Error return value of `watcher.Close` is not checked (errcheck)
	defer watcher.Close()
	                   ^
internal/tui/components/chat/editor.go:92:15: Error return value of `tmpfile.Close` is not checked (errcheck)
	tmpfile.Close()
	             ^
internal/tui/components/chat/message.go:340:17: Error return value of `json.Unmarshal` is not checked (errcheck)
		json.Unmarshal([]byte(toolCall.Input), &params)
		              ^
internal/tui/components/chat/message.go:345:17: Error return value of `json.Unmarshal` is not checked (errcheck)
		json.Unmarshal([]byte(toolCall.Input), &params)
		              ^
internal/tui/components/chat/message.go:350:17: Error return value of `json.Unmarshal` is not checked (errcheck)
		json.Unmarshal([]byte(toolCall.Input), &params)
		              ^
internal/tui/image/images.go:62:26: Error return value of `imageContent.Close` is not checked (errcheck)
	defer imageContent.Close()
	                        ^
internal/tui/tui.go:319:30: Error return value of `a.app.CoderAgent.Summarize` is not checked (errcheck)
			a.app.CoderAgent.Summarize(ctx, a.selectedSession.ID)
			                          ^
internal/tui/components/chat/message.go:188:3: ineffectual assignment to content (ineffassign)
		content = renderMessage(thinkingContent, false, msg.ID == focusedUIMessageId, width)
		^
internal/tui/components/dialog/arguments.go:229:2: ineffectual assignment to maxWidth (ineffassign)
	maxWidth = min(maxWidth, m.width-10)
	^
internal/app/lsp.go:65:41: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
	watchCtx = context.WithValue(watchCtx, "serverName", name)
	                                       ^
internal/format/format.go:89:18: QF1004: could use strings.ReplaceAll instead (staticcheck)
		jsonEscaped := strings.Replace(content, "\\", "\\\\", -1)
		               ^
internal/format/format.go:90:17: QF1004: could use strings.ReplaceAll instead (staticcheck)
		jsonEscaped = strings.Replace(jsonEscaped, "\"", "\\\"", -1)
		              ^
internal/format/format.go:91:17: QF1004: could use strings.ReplaceAll instead (staticcheck)
		jsonEscaped = strings.Replace(jsonEscaped, "\n", "\\n", -1)
		              ^
internal/llm/provider/anthropic.go:250:2: SA9003: empty branch (staticcheck)
	if cfg.Debug {
	^
internal/llm/provider/anthropic.go:276:6: QF1003: could use tagged switch on event.ContentBlock.Type (staticcheck)
					if event.ContentBlock.Type == "text" {
					^
internal/llm/provider/gemini.go:158:2: QF1002: could use tagged switch on reason (staticcheck)
	switch {
	^
internal/llm/provider/gemini.go:407:2: QF1007: could merge conditional assignment into variable declaration (staticcheck)
	isRateLimit := false
	^
internal/llm/provider/openai.go:169:5: S1002: should omit comparison to bool constant, can be simplified to o.providerOptions.model.CanReason (staticcheck)
	if o.providerOptions.model.CanReason == true {
	   ^
internal/llm/provider/openai.go:287:16: QF1008: could remove embedded field "ChatCompletion" from selector (staticcheck)
				if len(acc.ChatCompletion.Choices[0].Message.ToolCalls) > 0 {
				           ^
internal/llm/tools/shell/shell.go:122:3: SA9003: empty branch (staticcheck)
		if err != nil {
		^
internal/lsp/watcher/watcher.go:312:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
	ctx = context.WithValue(ctx, "workspaceWatcher", w)
	                             ^
internal/lsp/watcher/watcher.go:317:32: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
		ctx = context.WithValue(ctx, "serverName", serverName)
		                             ^
internal/tui/components/chat/message.go:320:2: S1017: should replace this if statement with an unconditional strings.TrimPrefix (staticcheck)
	if strings.HasPrefix(path, wd) {
	^
internal/tui/components/chat/message.go:323:2: S1017: should replace this if statement with an unconditional strings.TrimPrefix (staticcheck)
	if strings.HasPrefix(path, "/") {
	^
internal/tui/components/chat/message.go:326:2: S1017: should replace this if statement with an unconditional strings.TrimPrefix (staticcheck)
	if strings.HasPrefix(path, "./") {
	^
internal/tui/components/chat/message.go:569:11: S1025: the argument is already a string, there's no need to use fmt.Sprintf (staticcheck)
			Render(fmt.Sprintf("%s", toolAction))
			       ^
internal/tui/components/chat/sidebar.go:183:5: S1009: should omit nil check; len() for nil maps is defined as zero (staticcheck)
	if m.modFiles == nil || len(m.modFiles) == 0 {
	   ^
internal/tui/layout/overlay.go:50:16: ST1023: should omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
		var shadowbg string = ""
		             ^
internal/diff/diff.go:566:6: func lipglossToHex is unused (unused)
func lipglossToHex(color lipgloss.Color) string {
     ^
internal/llm/provider/gemini.go:426:24: func (*geminiClient).toolCalls is unused (unused)
func (g *geminiClient) toolCalls(resp *genai.GenerateContentResponse) []message.ToolCall {
                       ^
internal/tui/components/chat/editor.go:41:6: type bluredEditorKeyMaps is unused (unused)
type bluredEditorKeyMaps struct {
     ^
internal/tui/components/chat/list.go:175:6: func formatTimeDifference is unused (unused)
func formatTimeDifference(unixTime1, unixTime2 int64) string {
     ^
internal/tui/components/core/status.go:261:20: func statusCmp.availableFooterMsgWidth is unused (unused)
func (m statusCmp) availableFooterMsgWidth(diagnostics, tokenInfo string) int {
                   ^
internal/tui/components/dialog/complete.go:17:2: field title is unused (unused)
	title string
	^
internal/tui/components/dialog/filepicker.go:80:2: field basePath is unused (unused)
	basePath       string
	^
internal/tui/components/dialog/filepicker.go:84:2: field err is unused (unused)
	err            error
	^
internal/tui/components/util/simple-list.go:32:2: field width is unused (unused)
	width               int
	^
internal/tui/components/util/simple-list.go:33:2: field height is unused (unused)
	height              int
	^
internal/tui/tui.go:671:20: func (*appModel).findCommand is unused (unused)
func (a *appModel) findCommand(id string) (dialog.Command, bool) {
                   ^
70 issues:
* errcheck: 38
* ineffassign: 2
* staticcheck: 19
* unused: 11

```